### PR TITLE
Fix atom feed generation when not mimetype

### DIFF
--- a/books/opds.py
+++ b/books/opds.py
@@ -37,7 +37,7 @@ def __get_mimetype(item):
 
     # The MIME Type was not stored in the database, try to guess it
     # from the filename:
-    mimetype, encoding = mimetypes.guess_type(item.original_path.url)
+    mimetype, _ = mimetypes.guess_type(item.book_file.url)
     if mimetype is not None:
         return mimetype
     else:


### PR DESCRIPTION
Fix a bug that caused the atom feed generation to crash if the Book
did not have its mimetype stored, which was introduced by mistake
at 1bade20.
