### PR TITLE
epub.py: unzip only cover image rather than whole file while parsing for import

### DIFF
--- a/books/epub.py
+++ b/books/epub.py
@@ -43,44 +43,16 @@ class Epub(object):
             self._tempdir = tempfile.mkdtemp()
 
             if not self._verify():
-                print 'Warning: This does not seem to be a valid epub file'
+                print 'Warning: This does not seem to be a valid ePub file'
 
             self._get_opf()
             self._get_ncx()
 
             opffile = self._zobject.open(self._opfpath)
             self._info = epubinfo.EpubInfo(opffile)
-
-            # self._unzip()
         except Exception as e:
             self.close()
             raise e
-
-    def _unzip(self):
-        # Use safe version (2.7+) if possible, that escapes dangerous names.
-        if version_info >= (2, 7, 4):
-            self._zobject.extractall(path=self._tempdir)
-            return
-
-        # TODO: further restrict the "safe" names (several slashes, relative
-        # paths, ...)
-        orig_cwd = os.getcwd()
-        try:
-            os.chdir(self._tempdir)
-            for name in self._zobject.namelist():
-                # Some weird zip file entries start with a slash, and we don't
-                # want to write to the root directory.
-                if name.startswith(os.path.sep):
-                    name = name[1:]
-                if name.endswith(os.path.sep) or name.endswith('\\'):
-                    os.makedirs(name)
-                else:
-                    self._zobject.extract(name)
-        except Exception as e:
-            raise e
-        finally:
-            # Make sure that we return to the original directory.
-            os.chdir(orig_cwd)
 
     def _unzip_file(self, name):
         # Use safe version (2.7+) if possible, that escapes dangerous names.
@@ -172,7 +144,7 @@ class Epub(object):
 
     def get_info(self):
         """
-        Returns a EpubInfo object for the open Epub file
+        Returns a EpubInfo object for the open ePpub file
         """
         return self._info
 

--- a/books/epub.py
+++ b/books/epub.py
@@ -144,7 +144,7 @@ class Epub(object):
 
     def get_info(self):
         """
-        Returns a EpubInfo object for the open ePpub file
+        Returns a EpubInfo object for the open ePub file
         """
         return self._info
 


### PR DESCRIPTION
I believe that's all that's need for #11. Took _unzip and made an _unzip_file which is added to _get_cover_image_path. If it looks ok, feel free to merge at your convenience. If it looks good, and _unzip is preferred to be removed to look cleaner, the code is still there in a modified form, feel free to do so or I can. Either way, I left it in case I missed something.

In the future, I'm not sure if there's preferred methods to commit and merge branches. For instance, if I'm experimenting, particularly with something minor, if it's nicer to some how, if possible, squash an already pushed branch into one, so it appears as one commit in master.
