### PR TITLE
Add post_delete handler for Book model to remove book_file and cover_img

### DIFF
--- a/books/models.py
+++ b/books/models.py
@@ -153,12 +153,13 @@ class Book(models.Model):
 
 @receiver(post_delete, sender=Book)
 def book_post_delete_handler(**kwargs):
+    """
+    Book model post_delete handler to ensure book and cover files are removed
+    with book. Check if optional cover exists to avoid error.
+    """
     book = kwargs['instance']
 
-    book_storage, book_file = book.book_file.storage, book.book_file.path
-    if book_file is not None:
-        book_storage.delete(book_file)
+    book.book_file.delete(save=False)
 
-    cover_storage, cover_file = book.cover_img.storage, book.cover_img.path
-    if cover_file is not None:
-        cover_storage.delete(cover_file)
+    if book.cover_img:
+        book.cover_img.delete(save=False)

--- a/books/models.py
+++ b/books/models.py
@@ -18,6 +18,8 @@
 from hashlib import sha256
 
 from django.db import models
+from django.db.models.signals import post_delete
+from django.dispatch import receiver
 
 from taggit.managers import TaggableManager  # NEW
 
@@ -147,3 +149,16 @@ class Book(models.Model):
     @models.permalink
     def get_absolute_url(self):
         return 'pathagar.books.views.book_detail', [self.pk]
+
+
+@receiver(post_delete, sender=Book)
+def book_post_delete_handler(**kwargs):
+    book = kwargs['instance']
+
+    book_storage, book_file = book.book_file.storage, book.book_file.path
+    if book_file is not None:
+        book_storage.delete(book_file)
+
+    cover_storage, cover_file = book.cover_img.storage, book.cover_img.path
+    if cover_file is not None:
+        cover_storage.delete(cover_file)

--- a/books/views.py
+++ b/books/views.py
@@ -177,7 +177,6 @@ def edit_book(request, book_id):
 
 @login_required
 def remove_book(request, book_id):
-    # TODO: delete the file and cover automatically.
     return delete_object(
         request,
         model=Book,


### PR DESCRIPTION
This should take care of deleting the book file and cover upon book delete. I found a note about .delete possibly removing the static_media folder if the field is empty. Whenever you get a chance, please review and improve upon as needed. Feel free to move the Book model to the top in models.py, if you'd like, in a separate commit if you also feel that it's more organized. :)

edit: Being happy I was able to figure it out, as well as having issues with rebase and squash to get it to be one commit, I forgot to comment. Please comment as needed and if the .delete issue on None is true, it'd probably be good to comment that as well. The receiver import may be unneeded then again maybe something should be done with receiver.
