### PR TITLE
Move sample epubs test helper to new module, add info

### DIFF
--- a/books/tests/sample_epubs.py
+++ b/books/tests/sample_epubs.py
@@ -1,0 +1,34 @@
+"""Helper for dealing with the sample epubs stored on resources.
+"""
+import os
+from collections import namedtuple
+
+from django.conf import settings
+
+
+RSRC_DIR = os.path.abspath(os.path.join(settings.CUR_DIR,
+                                        'resources/epubsamples'))
+SampleEpub = namedtuple('SampleEpub', ('key', 'filename', 'fullpath',
+                                       'is_valid', 'has_cover'))
+
+# List of sample epubs, with their interesting properties.
+# TODO: the 'fullpath' property is a bit messy at the moment, should be
+# calculated automatically based on 'filename'.
+EPUBS_ALL = [SampleEpub('epub30-spec', 'epub30-spec.epub',
+                        os.path.join(RSRC_DIR, 'epub30-spec.epub'),
+                        True, False),
+             SampleEpub('figure-gallery', 'figure-gallery-bindings.epub',
+                        os.path.join(RSRC_DIR, 'figure-gallery-bindings.epub'),
+                        True, True),
+             SampleEpub('not-epub', 'not-an-epub.epub',
+                        os.path.join(RSRC_DIR, 'not-an-epub.epub'),
+                        False, False),
+             SampleEpub('not-epub-zip', 'not-an-epub-but-a-zip.epub',
+                        os.path.join(RSRC_DIR, 'not-an-epub-but-a-zip.epub'),
+                        False, False)]
+
+# Convenience lists of epub, using 'key' as the identifier.
+EPUBS_VALID = [epub for epub in EPUBS_ALL if epub.is_valid]
+EPUBS_NOT_VALID = [epub for epub in EPUBS_ALL if not epub.is_valid]
+EPUBS_COVER = [epub for epub in EPUBS_ALL if epub.has_cover]
+EPUBS_NOT_COVER = [epub for epub in EPUBS_ALL if not epub.has_cover]

--- a/books/tests/test_commands.py
+++ b/books/tests/test_commands.py
@@ -5,36 +5,12 @@ import shutil
 
 from mock import patch
 
-from django.conf import settings
 from django.core.files.storage import FileSystemStorage
 from django.core.management import call_command
 from django.test import TransactionTestCase
 
 from books import models
-
-
-# TODO: move these variables to a separate module, for using in other tests;
-# add more sample ebooks, and tidy up the tree structure when refactoring.
-RSRC_DIR = os.path.abspath(os.path.join(settings.CUR_DIR,
-                                        'resources/epubsamples'))
-
-EPUBS = {'epub30-spec': 'epub30-spec.epub',
-         'figure-gallery': 'figure-gallery-bindings.epub',
-         'not-epub': 'not-an-epub.epub',
-         'not-epub-zip': 'not-an-epub-but-a-zip.epub'}
-
-EPUBS_ALL = [key for key in EPUBS.iterkeys()]
-EPUBS_VALID = ('epub30-spec', 'figure-gallery')
-EPUBS_NOT_VALID = ('not-epub', 'not-epub-zip')
-EPUBS_COVER = ('figure-gallery',)
-EPUBS_NOT_COVER = ('epub30-spec',)
-
-
-def _src_epub(name):
-    """Return the absolute path of a sample epub. `name` should be a valid
-    key in EPUBS.
-    """
-    return os.path.join(RSRC_DIR, EPUBS[name])
+import sample_epubs
 
 
 class CommandAddEpubTest(TransactionTestCase):
@@ -61,7 +37,7 @@ class CommandAddEpubTest(TransactionTestCase):
         """Test the `addepub` command in "copy files" mode (default).
         """
         # Try to import all the sample epubs.
-        src_epubs = [_src_epub(i) for i in EPUBS_ALL]
+        src_epubs = [epub.fullpath for epub in sample_epubs.EPUBS_ALL]
         call_command('addepub', *src_epubs)
 
         # Get the list of output files.
@@ -69,17 +45,18 @@ class CommandAddEpubTest(TransactionTestCase):
         media_covers = os.listdir(os.path.join(self.tmp_media_root, 'covers'))
 
         # Make assertions on the VALID epubs.
-        self.assertEqual(models.Book.objects.count(), len(EPUBS_VALID))
-        for key in EPUBS_VALID:
+        self.assertEqual(models.Book.objects.count(),
+                         len(sample_epubs.EPUBS_VALID))
+        for epub in sample_epubs.EPUBS_VALID:
             # Assert the Book with that file exists on the DB.
-            qs = models.Book.objects.filter(book_file__endswith=EPUBS[key])
+            qs = models.Book.objects.filter(book_file__endswith=epub.filename)
             self.assertEqual(qs.count(), 1)
 
             # Assert some properties of the Book.
             book = qs.get()
-            self.assertEqual(book.original_path, _src_epub(key))
+            self.assertEqual(book.original_path, epub.fullpath)
 
-            if key in EPUBS_COVER:
+            if epub in sample_epubs.EPUBS_COVER:
                 self.assertTrue(book.cover_img)
                 self.assertTrue([f for f in media_covers
                                  if f.startswith('%s.' % book.pk)])
@@ -88,28 +65,28 @@ class CommandAddEpubTest(TransactionTestCase):
                 self.assertFalse(book.cover_img)
 
             # Assert that the file is on media, is copied, and equal to source.
-            self.assertIn(EPUBS[key], media_books)
+            self.assertIn(epub.filename, media_books)
             self.assertFalse(os.path.islink(book.book_file.path))
-            self.assertTrue(filecmp.cmp(book.book_file.path, _src_epub(key)))
+            self.assertTrue(filecmp.cmp(book.book_file.path, epub.fullpath))
 
         # Make assertions on the NOT_VALID epubs.
-        for key in EPUBS_NOT_VALID:
+        for epub in sample_epubs.EPUBS_NOT_VALID:
             # Assert no Book with that file exists on the DB.
-            qs = models.Book.objects.filter(book_file__endswith=EPUBS[key])
+            qs = models.Book.objects.filter(book_file__endswith=epub.filename)
             self.assertFalse(qs.exists())
 
             # Assert that the file is not on media.
-            self.assertNotIn(EPUBS[key], media_books)
+            self.assertNotIn(epub.filename, media_books)
 
         # Make assertions on the files as a whole.
-        self.assertEqual(len(media_books), len(EPUBS_VALID))
-        self.assertEqual(len(media_covers), len(EPUBS_COVER))
+        self.assertEqual(len(media_books), len(sample_epubs.EPUBS_VALID))
+        self.assertEqual(len(media_covers), len(sample_epubs.EPUBS_COVER))
 
     def test_addepub_symlink(self):
         """Test the `addepub` command in "symbolic links" mode.
         """
         # Try to import all the sample epubs.
-        src_epubs = [_src_epub(i) for i in EPUBS_ALL]
+        src_epubs = [epub.fullpath for epub in sample_epubs.EPUBS_ALL]
         call_command('addepub', *src_epubs, use_symlink=True)
 
         # Get the list of output files.
@@ -117,17 +94,18 @@ class CommandAddEpubTest(TransactionTestCase):
         media_covers = os.listdir(os.path.join(self.tmp_media_root, 'covers'))
 
         # Make assertions on the VALID epubs.
-        self.assertEqual(models.Book.objects.count(), len(EPUBS_VALID))
-        for key in EPUBS_VALID:
+        self.assertEqual(models.Book.objects.count(),
+                         len(sample_epubs.EPUBS_VALID))
+        for epub in sample_epubs.EPUBS_VALID:
             # Assert the Book with that file exists on the DB.
-            qs = models.Book.objects.filter(book_file__endswith=EPUBS[key])
+            qs = models.Book.objects.filter(book_file__endswith=epub.filename)
             self.assertEqual(qs.count(), 1)
 
             # Assert some properties of the Book.
             book = qs.get()
-            self.assertEqual(book.original_path, _src_epub(key))
+            self.assertEqual(book.original_path, epub.fullpath)
 
-            if key in EPUBS_COVER:
+            if epub in sample_epubs.EPUBS_COVER:
                 self.assertTrue(book.cover_img)
                 self.assertTrue([f for f in media_covers
                                  if f.startswith('%s.' % book.pk)])
@@ -135,20 +113,20 @@ class CommandAddEpubTest(TransactionTestCase):
             else:
                 self.assertFalse(book.cover_img)
 
-            # Assert that the file is on media, is copied, and equal to source.
-            self.assertIn(EPUBS[key], media_books)
+            # Assert that the file is on media, is linked, and equal to source.
+            self.assertIn(epub.filename, media_books)
             self.assertTrue(os.path.islink(book.book_file.path))
-            self.assertTrue(filecmp.cmp(book.book_file.path, _src_epub(key)))
+            self.assertTrue(filecmp.cmp(book.book_file.path, epub.fullpath))
 
         # Make assertions on the NOT_VALID epubs.
-        for key in EPUBS_NOT_VALID:
+        for epub in sample_epubs.EPUBS_NOT_VALID:
             # Assert no Book with that file exists on the DB.
-            qs = models.Book.objects.filter(book_file__endswith=EPUBS[key])
+            qs = models.Book.objects.filter(book_file__endswith=epub.filename)
             self.assertFalse(qs.exists())
 
             # Assert that the file is not on media.
-            self.assertNotIn(EPUBS[key], media_books)
+            self.assertNotIn(epub.filename, media_books)
 
         # Make assertions on the files as a whole.
-        self.assertEqual(len(media_books), len(EPUBS_VALID))
-        self.assertEqual(len(media_covers), len(EPUBS_COVER))
+        self.assertEqual(len(media_books), len(sample_epubs.EPUBS_VALID))
+        self.assertEqual(len(media_covers), len(sample_epubs.EPUBS_COVER))

--- a/resources/README.md
+++ b/resources/README.md
@@ -1,0 +1,17 @@
+Sample ePubs
+------------
+At `resources/epubsamples`:
+
+| File                         | Valid              | Cover              | Description                                        | Source                                |
+|------------------------------|--------------------|--------------------|----------------------------------------------------|---------------------------------------|
+| epub30-spec.epub             | :white_check_mark: |                    | EPUB 3.0 Specification                             | https://github.com/IDPF/epub3-samples |
+| figure-gallery-bindings.epub | :white_check_mark: | :white_check_mark: | Figure Gallery                                     | https://github.com/IDPF/epub3-samples |
+| not-an-epub-but-a-zip.epub   |                    |                    | Invalid file, zipped version of `not-an-epub.epub` |                                       |
+| not-an-epub.epub             |                    |                    | Invalid file with the string `I'm not an epub!`    |                                       |
+
+Adding a sample ePub
+--------------------
+* Copy it to `resources/epubsamples`.
+* Append it to `EPUBS_ALL` on `books/tests/sample_epubs.py`.
+* Check that the tests are successful.
+* Update this page!


### PR DESCRIPTION
Refactor a bit the tests so all the sample epub functions are moved onto a new `tests.sample_epubs` module, and add a tiny page with a summary of the current epubs used for testing.
