### PR TITLE
Add resync command, tests, storage tweak

### DIFF
--- a/books/management/commands/resync.py
+++ b/books/management/commands/resync.py
@@ -1,0 +1,119 @@
+from optparse import make_option
+import os
+
+from django.conf import settings
+from django.core.files import File
+from django.core.management.base import BaseCommand, CommandError
+
+from books import models
+from books.storage import LinkableFile
+
+from addepub import get_epubs_paths
+
+
+class Command(BaseCommand):
+    # TODO: on Django 1.8+, optparse should be used.
+    help = ("Update the database files information, replacing the pointers "
+            "to the original files and the symbolic links to match the "
+            "specified ITEMs if the database contains a Book that is "
+            "considered a duplicate (having the same sha256 hash). ITEMs "
+            "can be either:\n"
+            "- a single file with '.epub' extension.\n"
+            "- a directory (in which case it is traversed recursively, "
+            "checking the files with '.epub' extension).")
+    args = '<ITEM ITEM ...>'
+
+    option_list = BaseCommand.option_list + (
+        make_option('-r', '--replace-strategy',
+                    choices=['original', 'always-link', 'always-copy'],
+                    dest='replace_strategy',
+                    default='original',
+                    help=('Select the strategy to use when replacing. Allowed '
+                          'values: "always-link" (always replace the file with'
+                          ' a symlink), "always-copy" (always use a copy of '
+                          'the file), "original" (default, use the same as '
+                          'the original Book is using).')
+                    ),
+    )
+
+    def handle(self, *args, **options):
+        epub_filenames = get_epubs_paths(args)
+
+        if not epub_filenames:
+            raise CommandError('No .epub files found on the specified paths.')
+
+        for filename in epub_filenames:
+            book, success = (None, False)
+            try:
+                book, success = self.process_epub(filename,
+                                                  options['replace_strategy'])
+            except Exception as e:
+                print 'Unhandled exception while processing: %s' % e
+
+            if book:
+                if success:
+                    print 'Book #%s (%s) modified (%s).' % (book.pk, book,
+                                                            book.original_path)
+                else:
+                    print 'Book #%s (%s) NOT modified.' % (book.pk, book)
+            else:
+                print 'No match found.'
+
+    def process_epub(self, filename, replace_strategy='original'):
+        """Parse a single EPUB from `filename`, updating `Book` if `filename`
+        already exists on the database:
+            - the `original_path` is updated to point to `filename`.
+            - if `book_file` is a symlink, the old symlink is deleted and a new
+            one pointing at `filename` is created.
+
+        Returns a tuple (Book, success), where Book will be None if not found.
+        """
+        # TODO: move prints to logging.
+        print '\nReimporting %s' % filename
+
+        # Check the sha256sum and try to find the Book.
+        file_sha256sum = models.sha256_sum(File(open(filename)))
+        try:
+            book = models.Book.objects.get(file_sha256sum=file_sha256sum)
+        except models.Book.DoesNotExist:
+            return (None, False)
+
+        # Prepare the changes.
+        info_dict = {'original_path': filename}
+        if replace_strategy == 'always-link':
+            # Remove previous file/link and create a new link.
+            book.book_file.delete()
+            info_dict['book_file'] = LinkableFile(open(filename))
+            pass
+        elif replace_strategy == 'always-copy':
+            # Remove previous file only if it was a link, create a new *copy*.
+            if os.path.islink(os.path.join(settings.MEDIA_ROOT,
+                                           book.book_file.path)):
+                book.book_file.delete()
+                info_dict['book_file'] = File(open(filename))
+        else:  # 'default'
+            # Remove previous file only if it was a link, create a new *link*..
+            if os.path.islink(os.path.join(settings.MEDIA_ROOT,
+                                           book.book_file.path)):
+                book.book_file.delete()
+                info_dict['book_file'] = LinkableFile(open(filename))
+
+        # Save and return the Book.
+        # TODO: if save fails, files might have been deleted and leave the
+        # model in inconsistent state - it's probably a better idea to delete
+        # files *after* a successful book.save().
+        try:
+            if 'book_file' in info_dict:
+                book.book_file.save(os.path.basename(filename),
+                                    info_dict['book_file'],
+                                    save=False)
+                print 'book saved at %s' % book.book_file
+            book.original_path = info_dict['original_path']
+            book.save()
+
+            return book, True
+        except Exception as e:
+            # TODO: check for possible risen exceptions at a finer grain.
+            raise e
+
+        return book, False


### PR DESCRIPTION
Add a new `resync` commands for helping the user reconcile back the
possible changes mades to the Django files on media. The command accepts
a list of items (dirs and files), and if a match is found on the DB, it
replaces `Book.book_file` and `Book.original_path` to match the new items.

It is meant to tackle an issue derived by the discussion in #1, by allowing the users to do something like:

```
$ python manage.py addepub /media/myepubs
(some time later ...)
$ mv /media/myepubs /the/new/epubs/folder
$ python manage.py resync /the/new/epubs/folder
```

And automagically have the Django DB (`Book.book_file` and `Book.original_path` for the matching items) updated.

It includes some tests and a tweak for a potential problem on `storage` when trying to delete symbolic links to broken files, as the default `FileSystemStorage` considers that the file "does not exist" in that case. Additionally, has a `--replace-strategy` option for tweaking the copy/link behaviour (defaulting to just honoring the original choice made by the user for a specific `Book` if not specified).

Some more manual testing would be welcome before merging to make sure it matches the problem that prompted this feature to be added, but hopefully should be close to being ready!
