### PR TITLE
Fix for unicode filenames on commands

### DIFF
--- a/books/management/commands/addepub.py
+++ b/books/management/commands/addepub.py
@@ -1,8 +1,11 @@
+from __future__ import unicode_literals
+
 from django.core.management.base import BaseCommand, CommandError
 from django.core.files import File
 from django.core.exceptions import ValidationError
 
 import os
+import sys
 
 from books import models
 from books.epub import Epub
@@ -50,11 +53,12 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         # Positional arguments.
-        parser.add_argument('item', nargs='+', type=unicode,
-                            help=("A file with '.epub' extension or a "
-                                  "directory (in which case it is traversed "
-                                  "recursively, adding all the files with "
-                                  "'.epub' extension)."))
+        parser.add_argument(
+            'item', nargs='+',
+            type=lambda s: s.decode(sys.getfilesystemencoding()),
+            help=("A file with '.epub' extension or a directory (in which "
+                  "case it is traversed recursively, adding all the files "
+                  "with '.epub' extension)."))
 
         # Named (optional) arguments.
         parser.add_argument(

--- a/books/management/commands/resync.py
+++ b/books/management/commands/resync.py
@@ -1,4 +1,7 @@
+from __future__ import unicode_literals
+
 import os
+import sys
 
 from django.conf import settings
 from django.core.files import File
@@ -18,11 +21,12 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         # Positional arguments
-        parser.add_argument('item', nargs='+', type=unicode,
-                            help=("A file with '.epub' extension or a "
-                                  "directory (in which case it is traversed "
-                                  "recursively, checking all the files with "
-                                  "'.epub' extension)."))
+        parser.add_argument(
+            'item', nargs='+',
+            type=lambda s: s.decode(sys.getfilesystemencoding()),
+            help=("A file with '.epub' extension or a directory (in which "
+                  "case it is traversed recursively, checking all the files "
+                  "with '.epub' extension)."))
 
         # Named (optional) arguments
         parser.add_argument(


### PR DESCRIPTION
Improve handling of files with unicode filenames on addepub and resync
commands, by decoding the args according to the file system encoding
and enforcing the use of unicode literals.

Please test it on the files that you encountered problems with (only unicode on the source filename has been tested - didn't explicitly test edge cases such as the cover file having unicode filename), and merge if successful!
