### PR TITLE
Switch to django-pure-pagination

### DIFF
--- a/books/views.py
+++ b/books/views.py
@@ -307,7 +307,8 @@ def _book_list(request, queryset, qtype=None, list_by='latest', **kwargs):
         'search_title': search_title,
         'search_author': search_author, 'list_by': list_by,
         'qstring': qstring,
-        'allow_public_add_book': settings.ALLOW_PUBLIC_ADD_BOOKS
+        'allow_public_add_book': settings.ALLOW_PUBLIC_ADD_BOOKS,
+        'allow_user_comments': settings.ALLOW_USER_COMMENTS,
     })
 
     return render(request, 'books/book_list.html', extra_context)

--- a/books/views.py
+++ b/books/views.py
@@ -22,7 +22,7 @@ from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.files import File
 from django.core.files.storage import FileSystemStorage
-from django.core.paginator import Paginator, InvalidPage, EmptyPage
+from django.core.paginator import InvalidPage
 from django.db.models import Count
 from django.http import Http404
 from django.http import HttpResponse
@@ -32,6 +32,7 @@ from django.shortcuts import render
 from django.views.generic.detail import DetailView
 from django.views.generic.edit import DeleteView, UpdateView
 from formtools.wizard.views import SessionWizardView
+from pure_pagination import Paginator, EmptyPage
 from sendfile import sendfile
 from taggit.models import Tag
 
@@ -286,13 +287,6 @@ def _book_list(request, queryset, qtype=None, list_by='latest', **kwargs):
     except (EmptyPage, InvalidPage):
         page_obj = paginator.page(paginator.num_pages)
 
-    # pagination
-    index = page_obj.number - 1
-    max_index = len(list(paginator.page_range))
-    start_index = index - 5 if index >= 10 else 0
-    end_index = index + 5 if index <= max_index - 10 else max_index
-    page_range = list(paginator.page_range)[start_index:end_index]
-
     # Build the query string:
     qstring = page_qstring(request)
 
@@ -310,7 +304,6 @@ def _book_list(request, queryset, qtype=None, list_by='latest', **kwargs):
         'q': q,
         'paginator': paginator,
         'page_obj': page_obj,
-        'page_range': page_range,
         'search_title': search_title,
         'search_author': search_author, 'list_by': list_by,
         'qstring': qstring,

--- a/pathagar/settings.py
+++ b/pathagar/settings.py
@@ -29,6 +29,7 @@ INSTALLED_APPS = [
     'formtools',
     'taggit',
     'django_comments',
+    'pure_pagination',
     # pathagar apps
     'books.apps.BooksConfig',
 ]
@@ -153,6 +154,11 @@ ALLOW_PUBLIC_ADD_BOOKS = False
 
 ALLOW_USER_COMMENTS = True
 
+PAGINATION_SETTINGS = {
+    'PAGE_RANGE_DISPLAYED': 5,
+    'MARGIN_PAGES_DISPLAYED': 1,
+    'SHOW_FIRST_PAGE_WHEN_INVALID': True,
+}
 
 # -- Local settings.
 # Deployment-specific variables are imported from local_settings.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ django-taggit==0.18.0
 Pillow==2.9.0  # https://github.com/python-pillow/Pillow/issues/1457
 django-contrib-comments==1.6.2
 django-formtools==1.0
+django-pure-pagination==0.3.0

--- a/static/style/bootstrap/bootstrap.css
+++ b/static/style/bootstrap/bootstrap.css
@@ -64,8 +64,8 @@
 .pagination > .active > span:focus {
   z-index: 3;
   color: #ffffff;
-  background-color: #337ab7;
-  border-color: #337ab7;
+  background-color: #2e9dfd;
+  border-color: #2e9dfd;
   cursor: default;
 }
 .pagination > .disabled > span,

--- a/static/style/bootstrap/bootstrap.css
+++ b/static/style/bootstrap/bootstrap.css
@@ -1,0 +1,113 @@
+/*!
+ * Bootstrap v3.3.5 (http://getbootstrap.com)
+ * Copyright 2011-2016 Twitter, Inc.
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+ */
+
+/*!
+ * Generated using the Bootstrap Customizer (https://getbootstrap.com/customize/?id=60e68f7e56ebe2914542)
+ * Config saved to config.json and https://gist.github.com/60e68f7e56ebe2914542
+ */
+/*!
+ * Bootstrap v3.3.6 (http://getbootstrap.com)
+ * Copyright 2011-2015 Twitter, Inc.
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+ */
+/*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
+
+.pagination {
+  display: inline-block;
+  padding-left: 0;
+  margin: 20px 0;
+  border-radius: 4px;
+}
+.pagination > li {
+  display: inline;
+}
+.pagination > li > a,
+.pagination > li > span {
+  position: relative;
+  float: left;
+  padding: 6px 12px;
+  line-height: 1.42857143;
+  text-decoration: none;
+  color: #2e9dfd;
+  background-color: #ffffff;
+  border: 1px solid #dddddd;
+  margin-left: -1px;
+}
+.pagination > li:first-child > a,
+.pagination > li:first-child > span {
+  margin-left: 0;
+  border-bottom-left-radius: 4px;
+  border-top-left-radius: 4px;
+}
+.pagination > li:last-child > a,
+.pagination > li:last-child > span {
+  border-bottom-right-radius: 4px;
+  border-top-right-radius: 4px;
+}
+.pagination > li > a:hover,
+.pagination > li > span:hover,
+.pagination > li > a:focus,
+.pagination > li > span:focus {
+  z-index: 2;
+  color: #2e9dfd;
+  background-color: #eeeeee;
+  border-color: #dddddd;
+}
+.pagination > .active > a,
+.pagination > .active > span,
+.pagination > .active > a:hover,
+.pagination > .active > span:hover,
+.pagination > .active > a:focus,
+.pagination > .active > span:focus {
+  z-index: 3;
+  color: #ffffff;
+  background-color: #337ab7;
+  border-color: #337ab7;
+  cursor: default;
+}
+.pagination > .disabled > span,
+.pagination > .disabled > span:hover,
+.pagination > .disabled > span:focus,
+.pagination > .disabled > a,
+.pagination > .disabled > a:hover,
+.pagination > .disabled > a:focus {
+  color: #777777;
+  background-color: #ffffff;
+  border-color: #dddddd;
+  cursor: default;
+}
+.pagination-lg > li > a,
+.pagination-lg > li > span {
+  padding: 10px 16px;
+  font-size: 18px;
+  line-height: 1.3333333;
+}
+.pagination-lg > li:first-child > a,
+.pagination-lg > li:first-child > span {
+  border-bottom-left-radius: 6px;
+  border-top-left-radius: 6px;
+}
+.pagination-lg > li:last-child > a,
+.pagination-lg > li:last-child > span {
+  border-bottom-right-radius: 6px;
+  border-top-right-radius: 6px;
+}
+.pagination-sm > li > a,
+.pagination-sm > li > span {
+  padding: 5px 10px;
+  font-size: 12px;
+  line-height: 1.5;
+}
+.pagination-sm > li:first-child > a,
+.pagination-sm > li:first-child > span {
+  border-bottom-left-radius: 3px;
+  border-top-left-radius: 3px;
+}
+.pagination-sm > li:last-child > a,
+.pagination-sm > li:last-child > span {
+  border-bottom-right-radius: 3px;
+  border-top-right-radius: 3px;
+}

--- a/static/style/style.css
+++ b/static/style/style.css
@@ -17,9 +17,8 @@ a[href$=".epub"] {
     background-image: url(blueprint/plugins/link-icons/icons/epub.png);
 }
 
-.pagination {
+div.paginator {
     text-align: right;
-    padding: 5px;
 }
 
 .current-page {
@@ -417,3 +416,43 @@ hr.comment {
     margin-bottom: 1em;
     height: 1px;
 }
+
+
+
+/*div.pagination {*/
+	/*background-color:#fff;*/
+	/*color:#48b9ef;*/
+	/*padding:10px 0 10px 0;*/
+	/*font-family: Arial, Helvetica, sans-serif;*/
+	/*font-size: 13px;*/
+	/*text-align:center;*/
+/*}*/
+
+/*div.pagination span.other {*/
+	/*color:gray;*/
+	/*text-decoration:none;*/
+/*}*/
+
+/*div.pagination a {*/
+	/*color:gray;*/
+	/*padding:7px 7px;*/
+	/*margin:0 2px;*/
+	/*text-decoration:none;*/
+	/*border:2px solid #f0f0f0;*/
+/*}*/
+
+/*div.pagination a:hover, div.pagination a:active {*/
+	/*border:2px solid #2e9dfd;*/
+	/*color:#2e9dfd;*/
+/*}*/
+
+/*div.pagination span.current {*/
+	/*padding:7px 7px;*/
+	/*border:2px solid #ff5a00;*/
+	/*color:#fff;*/
+	/*font-weight:bold;*/
+	/*background-color:#ff6c16;*/
+/*}*/
+/*div.pagination span.disabled {*/
+	/*display:none;*/
+/*}*/

--- a/static/style/style.css
+++ b/static/style/style.css
@@ -321,7 +321,7 @@ label {
 
 .list_header {
     margin-top: 1.5em;
-    margin-bottom: 0;
+    margin-bottom: 1em;
     font-size: 150%;
 }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -15,7 +15,7 @@
         <!--[if lt IE 8]>
             <link rel="stylesheet" href="{% static "style/blueprint/ie.css" %}" type="text/css" media="screen, projection">
         <![endif]-->
-
+        <link rel="stylesheet" href="{% static "style/bootstrap/bootstrap.css" %}" type="text/css">
         <link rel="stylesheet" href="{% static "style/style.css" %}" type="text/css">
 
         <title>{% block title %}{% endblock %}</title>

--- a/templates/books/book_detail.html
+++ b/templates/books/book_detail.html
@@ -45,7 +45,7 @@
 
             <div class="detail_info">
                 <div class="span-4">{% trans "Publisher:" %}</div>
-                <div class="span-6">{{ book.dc_publisher }}</div>
+                <div class="span-6"><a href="{% url "by_title" %}?q={{ book.dc_publisher }}">{{ book.dc_publisher }}</a></div>
                 <br/>
                 {% if book.tags.count != 0 %}
                     <div class="span-4">{% trans "Tags:" %}</div>
@@ -73,9 +73,9 @@
                 <div class="span-4">{% trans "Added:" %}</div>
                 <div class="span-6">
                     {% blocktrans with time_added=book.time_added|timesince %}{{ time_added }} ago {% endblocktrans %}</div>
-                <br/>
-                <div class="span-4">{% trans "Size:" %}</div>
-                <div class="span-6">{{ book.book_file.size|filesizeformat }}</div>
+{#                <br/>#}
+{#                <div class="span-4">{% trans "Size:" %}</div>#}
+{#                <div class="span-6">{{ book.book_file.size|filesizeformat }}</div>#}
                 <br/>
                 <div class="span-4">{% trans "Downloads:" %}</div>
                 <div class="span-6">{{ book.downloads }}</div>

--- a/templates/books/book_detail.html
+++ b/templates/books/book_detail.html
@@ -58,8 +58,8 @@
                         {% endfor %}
 
                     </div>
-                {% endif %}
                 <br/>
+                {% endif %}
                 <div class="span-4">{% trans "Published:" %}</div>
                 <div class="span-6">{{ book.dc_issued }}</div>
                 <br/>

--- a/templates/books/book_list.html
+++ b/templates/books/book_list.html
@@ -71,44 +71,7 @@
         <h4 class="list_header">{% trans "Tag:" %} {{ tag }}</h4>
     {% endif %}
 
-{#    <div class="prepend-12 pagination">#}
-{#    <span class="step-links">#}
-{#        {% if page_obj.has_previous %}#}
-{#            <a href="?page={{ page_obj.previous_page_number }}{% if q %}&q={{ q }} {% endif %}">{% trans "Previous" %}</a>#}
-{#        {% endif %}#}
-{##}
-{#        <span class="current-page"#}
-{#              style="font-size:100%;font-weight:normal;top:0">#}
-{#            &nbsp;{{ page_obj.number }} {% trans "of" %}#}
-{#            {{ paginator.num_pages }}&nbsp;#}
-{#        </span>#}
-{##}
-{#        {% if page_obj.has_next %}#}
-{#            <a href="?page=#}
-{#                    {{ page_obj.next_page_number }}{% if q %}&q={{ q }} {% endif %}">{% trans "Next" %}</a>#}
-{#        {% endif %}#}
-{#    </span>#}
-{#    </div>#}
-
-        <!-- new paginator -->
-        <div class="prepend-12 pagination">
-        {% if page_obj.has_previous %}
-            <a class="prev btn btn-info" href="?page=1">{% trans "First" %}</a>
-            <a href="?page=
-                    {{ page_obj.previous_page_number }}{% if q %}&q={{ q }} {% endif %}">{% trans "Previous" %}</a>
-        {% endif %}
-                {% for pg in page_range %}
-                    {% if page_obj.number == pg %}
-                            <a href="?page={{ pg }}" class="btn btn-default">{{ pg }}</a>
-                    {% else %}
-                        <a href="?page={{ pg }}" class="btn">{{ pg }}</a>
-                    {% endif %}
-                {% endfor %}
-        {% if page_obj.has_next %}
-            <a href="?page={{ page_obj.next_page_number }}{% if q %}&q={{ q }} {% endif %}">{% trans "Next" %}</a>
-            <a class="next btn btn-info" href="?page={{ paginator.num_pages }}">{% trans "Last" %}</a>
-        {% endif %}
-    </div>
+    {% include "pagination.html" %}
 
     <table id="book_list" class="hover">
         <thead>
@@ -189,49 +152,33 @@
 
     {#<li>Showing matches <em>{{ page_obj.start_index }}</em> to <em>{{ page_obj.end_index }}</em></li>#}
 
-    <div class="prepend-12 pagination">
-    <span class="step-links">
-        {% if page_obj.has_previous %}
-            <a href="?page={{ page_obj.previous_page_number }}{% if q %}&q={{ q }} {% endif %}">{% trans "Previous" %}</a>
-        {% endif %}
+    {% include "pagination.html" %}
 
-        <span class="current-page"
-              style="font-size:100%;font-weight:normal;top:0">
-            &nbsp;{{ page_obj.number }} {% trans "of" %}
-            {{ paginator.num_pages }}&nbsp;
-        </span>
-
-        {% if page_obj.has_next %}
-            <a href="?page={{ page_obj.next_page_number }}{% if q %}&q={{ q }} {% endif %}">{% trans "Next" %}</a>
-        {% endif %}
-    </span>
+    <hr class="space">
+    <div class="box">
+        <ul class="stats">
+            <li>{% trans "Published eBooks:" %} {{ published_books }}</li>
+            {% if user.is_authenticated %}
+                <li>{% trans "Unpublished eBooks:" %}
+                    {{ unpublished_books }}</li>
+            {% endif %}
+        </ul>
+        {#            <hr>#}
+        {#            {% if tag %}#}
+        {#                <ul class="stats">#}
+        {#                    <li>Showing books with tag <em>{{ tag.name }}</em></li>#}
+        {#                </ul>#}
+        {#            {% endif %}#}
+        {#            {% ifnotequal book_list.count total_books %}#}
+        {#                <ul class="stats">#}
+        {#                    <li>Number of ebooks in search result: <em>{{ book_list.count }}</em></li>#}
+        {#                    <li>Showing matches <em>{{ page_obj.start_index }}</em> to <em>{{ page_obj.end_index }}</em></li>#}
+        {#                </ul>#}
+        {#            {% else %}#}
+        {#                <ul class="stats">#}
+        {#                    <li>Showing entire collection.</li>#}
+        {#                </ul>#}
+        {#            {% endifnotequal %}#}
     </div>
-
-        <hr class="space">
-        <div class="box">
-            <ul class="stats">
-                <li>{% trans "Published eBooks:" %} {{ published_books }}</li>
-                {% if user.is_authenticated %}
-                    <li>{% trans "Unpublished eBooks:" %}
-                        {{ unpublished_books }}</li>
-                {% endif %}
-            </ul>
-            {#            <hr>#}
-            {#            {% if tag %}#}
-            {#                <ul class="stats">#}
-            {#                    <li>Showing books with tag <em>{{ tag.name }}</em></li>#}
-            {#                </ul>#}
-            {#            {% endif %}#}
-            {#            {% ifnotequal book_list.count total_books %}#}
-            {#                <ul class="stats">#}
-            {#                    <li>Number of ebooks in search result: <em>{{ book_list.count }}</em></li>#}
-            {#                    <li>Showing matches <em>{{ page_obj.start_index }}</em> to <em>{{ page_obj.end_index }}</em></li>#}
-            {#                </ul>#}
-            {#            {% else %}#}
-            {#                <ul class="stats">#}
-            {#                    <li>Showing entire collection.</li>#}
-            {#                </ul>#}
-            {#            {% endifnotequal %}#}
-        </div>
 
 {% endblock %}

--- a/templates/books/book_list.html
+++ b/templates/books/book_list.html
@@ -87,7 +87,9 @@
                 <th><a data-name="latest"
                        href="{% url "latest" %}?q={{ q|urlencode }}">{% trans "Added" %}</a>
                 </th>
-                <th class="list_number">❝</th>
+                {% if allow_user_comments %}
+                    <th class="list_number">❝</th>
+                {% endif %}
                 <th class="list_number"><a data-name="by-author"
                                               href="{% url "most_downloaded" %}?q={{ q|urlencode }}">⬇</a>
                 </th>
@@ -99,7 +101,9 @@
                 <th class="th_date_added"><a data-name="latest" href=
                         "{% url "latest" %}">
                     {% trans "Added" %}</a></th>
-                <th class="list_number">❝</th>
+                {% if allow_user_comments %}
+                    <th class="list_number">❝</th>
+                {% endif %}
                 <th class="list_number"><a data-name="by-author"
                                               href="{% url "most_downloaded" %}">⬇</a>
                 </th>
@@ -139,8 +143,10 @@
                 <td class="list_date">
                     {% blocktrans with time_added=book.time_added|timesince %}{{ time_added }} ago{% endblocktrans %}</td>
                 <!-- date:'Y-m-d H:i' -->
-                {% get_comment_count for book as comment_count %}
-                <td class="list_number">{{ comment_count }}</td>
+                {% if allow_user_comments %}
+                    {% get_comment_count for book as comment_count %}
+                    <td class="list_number">{{ comment_count }}</td>
+                {% endif %}
                 <td class="list_number">{{ book.downloads }}</td>
                 <td class="list_download_link"><a class="download"
                                                   href="{% url "book_download" book.pk %}">⬇︎</a>

--- a/templates/pagination.html
+++ b/templates/pagination.html
@@ -11,7 +11,7 @@
                 {% ifequal page page_obj.number %}
                     <li class="active"><a href="#">{{ page }}</a></li>
                 {% else %}
-                    <li><a href="?{{ page.querystring }}">{{ page }}</a></li>
+                    <li><a href="?page={{ page }}{% if q %}&q={{ q }}{% endif %}">{{ page }}</a></li>
                 {% endifequal %}
             {% else %}
                 <li class="disabled"><a href="#">...</a></li>

--- a/templates/pagination.html
+++ b/templates/pagination.html
@@ -8,7 +8,7 @@
         {% for page in page_obj.pages %}
             {% if page %}
                 {% ifequal page page_obj.number %}
-                    <li><a href="#">{{ page }}</a></li>
+                    <li class="active"><a href="#">{{ page }}</a></li>
                 {% else %}
                     <li><a href="?{{ page.querystring }}">{{ page }}</a></li>
                 {% endifequal %}

--- a/templates/pagination.html
+++ b/templates/pagination.html
@@ -1,0 +1,25 @@
+<div style="text-align:right">
+    <ul class="pagination">
+        {% if page_obj.has_previous %}
+            <li><a href="?{{ page_obj.previous_page_number.querystring }}">&lsaquo;&lsaquo;</a></li>
+        {% else %}
+            <li class="disabled"><a href="#">&lsaquo;&lsaquo;</a></li>
+        {% endif %}
+        {% for page in page_obj.pages %}
+            {% if page %}
+                {% ifequal page page_obj.number %}
+                    <li><a href="#">{{ page }}</a></li>
+                {% else %}
+                    <li><a href="?{{ page.querystring }}">{{ page }}</a></li>
+                {% endifequal %}
+            {% else %}
+                <li class="disabled"><a href="#">...</a></li>
+            {% endif %}
+        {% endfor %}
+        {% if page_obj.has_next %}
+            <li><a href="?{{ page_obj.next_page_number.querystring }}">&rsaquo;&rsaquo;</a></li>
+        {% else %}
+            <li class="disabled"><a href="#">&rsaquo;&rsaquo;</a></li>
+        {% endif %}
+    </ul>
+</div>

--- a/templates/pagination.html
+++ b/templates/pagination.html
@@ -1,3 +1,4 @@
+{% if page_obj.paginator.num_pages > 1 %}
 <div style="text-align:right">
     <ul class="pagination">
         {% if page_obj.has_previous %}
@@ -23,3 +24,4 @@
         {% endif %}
     </ul>
 </div>
+{%endif%}


### PR DESCRIPTION
django-pure-pagination looks to be the most maintained of any of the available paginators, and the best thing is it requires no code changes. I liked the Bootstrap pagination theme the most, so I used their builder to make a CSS file with only pagination and then stripped out the few remaining unrelated styles.

Have a look. I think with this we can close #33. Looks good to me and no effort needed to create our own code.

<img width="1001" alt="capture d ecran 2016-02-12 a 22 56 15" src="https://cloud.githubusercontent.com/assets/13608624/13026412/f0c9787e-d1db-11e5-84a0-f220ae0d851c.png">

The repo if you'd like to take a look:

https://github.com/jamespacileo/django-pure-pagination
