### PR TITLE
Unify BookEditView and AddBookWizard step 2 views

### DIFF
--- a/accounts/migrations/0003_auto_20160305_1942.py
+++ b/accounts/migrations/0003_auto_20160305_1942.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounts', '0002_auto_20160222_1003'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='profile',
+            name='gender',
+            field=models.PositiveSmallIntegerField(blank=True, null=True, verbose_name='gender', choices=[(1, 'Male'), (2, 'Female')]),
+        ),
+        migrations.AlterField(
+            model_name='profile',
+            name='language',
+            field=models.CharField(default=b'en', help_text='Default language.', max_length=5, verbose_name='language', choices=[(b'af', b'Afrikaans'), (b'ar', b'Arabic'), (b'ast', b'Asturian'), (b'az', b'Azerbaijani'), (b'bg', b'Bulgarian'), (b'be', b'Belarusian'), (b'bn', b'Bengali'), (b'br', b'Breton'), (b'bs', b'Bosnian'), (b'ca', b'Catalan'), (b'cs', b'Czech'), (b'cy', b'Welsh'), (b'da', b'Danish'), (b'de', b'German'), (b'el', b'Greek'), (b'en', b'English'), (b'en-au', b'Australian English'), (b'en-gb', b'British English'), (b'eo', b'Esperanto'), (b'es', b'Spanish'), (b'es-ar', b'Argentinian Spanish'), (b'es-mx', b'Mexican Spanish'), (b'es-ni', b'Nicaraguan Spanish'), (b'es-ve', b'Venezuelan Spanish'), (b'et', b'Estonian'), (b'eu', b'Basque'), (b'fa', b'Persian'), (b'fi', b'Finnish'), (b'fr', b'French'), (b'fy', b'Frisian'), (b'ga', b'Irish'), (b'gl', b'Galician'), (b'he', b'Hebrew'), (b'hi', b'Hindi'), (b'hr', b'Croatian'), (b'hu', b'Hungarian'), (b'ia', b'Interlingua'), (b'id', b'Indonesian'), (b'io', b'Ido'), (b'is', b'Icelandic'), (b'it', b'Italian'), (b'ja', b'Japanese'), (b'ka', b'Georgian'), (b'kk', b'Kazakh'), (b'km', b'Khmer'), (b'kn', b'Kannada'), (b'ko', b'Korean'), (b'lb', b'Luxembourgish'), (b'lt', b'Lithuanian'), (b'lv', b'Latvian'), (b'mk', b'Macedonian'), (b'ml', b'Malayalam'), (b'mn', b'Mongolian'), (b'mr', b'Marathi'), (b'my', b'Burmese'), (b'nb', b'Norwegian Bokmal'), (b'ne', b'Nepali'), (b'nl', b'Dutch'), (b'nn', b'Norwegian Nynorsk'), (b'os', b'Ossetic'), (b'pa', b'Punjabi'), (b'pl', b'Polish'), (b'pt', b'Portuguese'), (b'pt-br', b'Brazilian Portuguese'), (b'ro', b'Romanian'), (b'ru', b'Russian'), (b'sk', b'Slovak'), (b'sl', b'Slovenian'), (b'sq', b'Albanian'), (b'sr', b'Serbian'), (b'sr-latn', b'Serbian Latin'), (b'sv', b'Swedish'), (b'sw', b'Swahili'), (b'ta', b'Tamil'), (b'te', b'Telugu'), (b'th', b'Thai'), (b'tr', b'Turkish'), (b'tt', b'Tatar'), (b'udm', b'Udmurt'), (b'uk', b'Ukrainian'), (b'ur', b'Urdu'), (b'vi', b'Vietnamese'), (b'zh-cn', b'Simplified Chinese'), (b'zh-hans', b'Simplified Chinese'), (b'zh-hant', b'Traditional Chinese'), (b'zh-tw', b'Traditional Chinese')]),
+        ),
+        migrations.AlterField(
+            model_name='profile',
+            name='user',
+            field=models.OneToOneField(related_name='profile', verbose_name='user', to=settings.AUTH_USER_MODEL),
+        ),
+    ]

--- a/books/epub.py
+++ b/books/epub.py
@@ -253,6 +253,7 @@ class Epub(object):
         # TODO: move to logging.
         for name, obj in [('Cover image', ret_cover_path),
                           ('Authors', info.creators),
+                          ('Publishers', info.publishers),
                           ('Language', info.language)]:
             if obj:
                 print '  [o] %s found: %s' % (name, obj)
@@ -265,9 +266,11 @@ class Epub(object):
                  'dc_language': info.language,
                  'dc_identifier': identifier,
                  'dc_issued': info.date,
-                 'mimetype': self._mimetype
+                 'mimetype': self._mimetype,
+                 'authors': info.creators,
+                 'publishers': info.publishers,
                  },
-                info.creators, info.publishers, ret_cover_path, info.subjects)
+                ret_cover_path, info.subjects)
 
     def close(self):
         """

--- a/books/forms.py
+++ b/books/forms.py
@@ -170,6 +170,12 @@ class BookMetadataForm(BookEditForm):
         exclude = ('book_file',
                    'original_path', 'mimetype', 'file_sha256sum', 'cover_img')
 
+        # TODO: move some of these to models directly?
+        labels = {'dc_language': _('Language'),
+                  'dc_issued': _('Published'),
+                  'a_status': _('Status'),
+                  }
+
 
 class AddLanguageForm(forms.ModelForm):
     class Meta:

--- a/books/forms.py
+++ b/books/forms.py
@@ -164,11 +164,11 @@ class BookUploadForm(forms.Form):
         return data
 
 
-class BookMetadataForm(forms.ModelForm):
+class BookMetadataForm(BookEditForm):
     class Meta:
         model = models.Book
-        exclude = ('book_file', 'original_path', 'mimetype',
-                   'file_sha256sum', 'cover_img')
+        exclude = ('book_file',
+                   'original_path', 'mimetype', 'file_sha256sum', 'cover_img')
 
 
 class AddLanguageForm(forms.ModelForm):

--- a/books/forms.py
+++ b/books/forms.py
@@ -15,8 +15,6 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
-import os
-
 from django import forms
 from django.utils.translation import ugettext as _
 
@@ -116,8 +114,7 @@ class BookEditForm(forms.ModelForm):
                   'a_status', 'tags', 'downloads', 'summary', 'cover_img']
 
         # TODO: move some of these to models directly?
-        labels = {
-                  'dc_language': _('Language'),
+        labels = {'dc_language': _('Language'),
                   'dc_issued': _('Published'),
                   'a_status': _('Status'),
                   }
@@ -148,11 +145,9 @@ class BookUploadForm(forms.Form):
         try:
             # Fetch information from the epub, and set it as attributes.
             epub = Epub(data)
-            info_dict, authors, publishers, cover_path, tags = \
-                epub.as_model_dict()
+            info_dict, cover_path, tags = epub.as_model_dict()
 
             # TODO: pass this info via a cleaner way.
-            # self.cleaned_data['authors'] = ",".join(authors)
             self.cleaned_data['original_path'] = data.name
             self.cleaned_data['info_dict'] = info_dict
             self.cleaned_data['cover_path'] = cover_path

--- a/books/migrations/0016_auto_20160305_1942.py
+++ b/books/migrations/0016_auto_20160305_1942.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import books.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('books', '0015_auto_20160229_0000'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='book',
+            name='cover_img',
+            field=books.models.ImageField(upload_to=b'covers', null=True, verbose_name='cover', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='book',
+            name='summary',
+            field=models.TextField(null=True, verbose_name='summary', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='book',
+            name='title',
+            field=models.CharField(max_length=255, verbose_name='title'),
+        ),
+    ]

--- a/books/models.py
+++ b/books/models.py
@@ -157,7 +157,7 @@ class Book(models.Model):
     file_sha256sum = models.CharField(max_length=64, unique=True)
     mimetype = models.CharField(max_length=200, null=True)
     cover_img = ImageField(_('cover'), upload_to='covers',
-                                  blank=True, null=True)
+                           blank=True, null=True)
     # cover_img_url = models.URLField(null=True, blank=True)
 
     # General fields

--- a/books/models.py
+++ b/books/models.py
@@ -36,6 +36,19 @@ def sha256_sum(_file):  # used to generate sha256 sum of book files
     return s.hexdigest()
 
 
+class ImageField(models.ImageField):
+    """Custom ImageField that automatically deletes the old image when it is
+    modified via a ModelForm (either by clicking on the "clear" checkbox, or
+    selecting a new image with the "upload" button).
+    """
+    def save_form_data(self, instance, data):
+        if data is not None:
+            file_ = getattr(instance, self.attname)
+            if file_ != data:
+                file_.delete(save=False)
+        super(ImageField, self).save_form_data(instance, data)
+
+
 @python_2_unicode_compatible
 class Author(models.Model):
     name = models.CharField(_('author'), unique=True, max_length=255)
@@ -143,7 +156,7 @@ class Book(models.Model):
     original_path = models.CharField(_('file'), max_length=1016)
     file_sha256sum = models.CharField(max_length=64, unique=True)
     mimetype = models.CharField(max_length=200, null=True)
-    cover_img = models.ImageField(_('cover'), upload_to='covers',
+    cover_img = ImageField(_('cover'), upload_to='covers',
                                   blank=True, null=True)
     # cover_img_url = models.URLField(null=True, blank=True)
 

--- a/books/templatetags/book_edit.py
+++ b/books/templatetags/book_edit.py
@@ -1,0 +1,16 @@
+from django import template
+
+register = template.Library()
+
+
+def field_width(field_name):
+    """Returns the field size for the bootstrap_field template tag.
+    """
+    if field_name in ['dc_issued', 'a_status', 'downloads']:
+        return 'col-md-3'
+    elif field_name in ['dc_language']:
+        return 'col-md-6'
+    else:
+        return 'col-md-10'
+
+register.filter('field_width', field_width)

--- a/books/views.py
+++ b/books/views.py
@@ -157,7 +157,6 @@ class AddBookWizard(SessionWizardView):
             # Update the initial values with the epub information.
             info_dict = self.storage.extra_data['info_dict']
             ret.update(info_dict)
-            ret['original_path'] = self.storage.extra_data['original_path']
             ret['a_status'] = Status.objects.get(
                 status=settings.DEFAULT_BOOK_STATUS
             )
@@ -165,7 +164,7 @@ class AddBookWizard(SessionWizardView):
             # TODO: Language, Author and Publishers are created even if the
             # Book is not saved, or they are changed by the user. Something
             # should be done (keep track of them and compare on saving, check
-            # dal docs, provide admin action to clean orphans, etc).
+            # dal docs, provide admin action to clean orphans, etc) about this.
 
             # Retrieve or create authors.
             ret['authors'] = []
@@ -178,7 +177,6 @@ class AddBookWizard(SessionWizardView):
                     Publisher.objects.get_or_create(name=p)[0].pk)
 
             try:
-                # TODO: Language is created even if the Book is not saved.
                 ret['dc_language'] = Language.objects.get_or_create_by_code(
                     info_dict['dc_language']
                 )
@@ -199,8 +197,9 @@ class AddBookWizard(SessionWizardView):
         uploaded_file = form_list[0].cleaned_data['epub_file']
         # Set file related parameters.
         self.instance.book_file = uploaded_file
-        self.instance.file_sha256sum = self.storage. \
+        self.instance.file_sha256sum = self.storage.\
             extra_data['file_sha256sum']
+        self.instance.original_path = self.storage.extra_data['original_path']
         self.instance.save()
         # Save the m2m fields.
         self.instance.authors.add(*form_list[1].cleaned_data['authors'])

--- a/static/style/style.css
+++ b/static/style/style.css
@@ -323,3 +323,8 @@ hr.comment {
     margin-bottom: 1em;
     height: 1px;
 }
+
+img.cover_detail {
+	width: 180px;
+	margin-bottom: 2em;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,8 +1,6 @@
 {% load i18n %}
 {% load static from staticfiles %}
-
 {% load bootstrap3 %}
-{% bootstrap_css %}
 
 <!DOCTYPE html>
 <html lang="en">
@@ -10,23 +8,25 @@
     <meta charset=utf-8/>
     <head>
         <link rel="stylesheet" href="{% static "style/bootstrap/bootstrap.css" %}" type="text/css">
+        <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.css">
+        <link href='https://fonts.googleapis.com/css?family=Oswald:400,700&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
+        {% bootstrap_css %}
         <link rel="stylesheet" href="{% static "style/style.css" %}" type="text/css">
         <link rel="stylesheet" href="{% static "style/sticky-footer.css" %}" type="text/css">
-
+        {% block extra_css %}
+        {% endblock %}
+        
         <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
-        <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.css">
-
         <script type="text/javascript"
-                src=" https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js"></script>
-
-        <link href='https://fonts.googleapis.com/css?family=Oswald:400,700&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
-
+                src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js"></script>
         {% bootstrap_javascript %}
+        {% block extra_js %}
+        {% endblock %}
 
         {% block head %}{% endblock %}
+        {% block extra_head %}{% endblock %}
 
         <title>{% block title %}{% endblock %}</title>
-
     </head>
 
 {#    <style>#}

--- a/templates/books/book_detail.html
+++ b/templates/books/book_detail.html
@@ -16,13 +16,7 @@
 {% block content %}
 
         <div class="detail_sidebar">
-            {% if  book.cover_img %}
-                <img src="{{ book.cover_img.url }}" alt="Cover" width=180px/>
-            {% else %}
-                <img src="{% static "images/book-icon.png" %}" alt="Cover"
-                        width=180px/>
-            {% endif %}
-            <br/><br/>
+            <img src="{% if book.cover_img %}{{ book.cover_img.url }}{% else %}{% static "images/book-icon.png" %}{% endif %}" alt="Cover"  class="cover_detail" />
             <div class="row">
                 <div class="col-sm-5">
                     <a href="{% url "book_download" book.pk %}"><span class="glyphicon glyphicon-arrow-down" aria-hidden="true"/><!--{% trans "Download" %}--></a>

--- a/templates/books/book_form.html
+++ b/templates/books/book_form.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% load static from staticfiles %}
 {% load bootstrap3 %}
+{% load book_edit %}
 
 {% block title %}{% if action == 'add' %}
     Add Book
@@ -10,153 +11,59 @@
 {% endif %}
 {% endblock %}
 
-{% block script %}
-    $(document).ready(function()
-    {
-    $(".hidden_body").hide();
-    $(".hidden_head").click(function()
-    {
-    $(this).next(".hidden_body").slideToggle(100);
-    });
-    $('#id_dc_identifier').example('ISBN');
-    });
+{% block extra_head %}
+{{ form.media }}
 {% endblock %}
 
-{% block head %}
-    <script type="text/javascript" src="{% static "js/RelatedObjectLookups.js" %}"></script>{% endblock %}
-
+{# TODO: i8n #}
 {% block content %}
-    {{ form.errors }}
-    <form enctype="multipart/form-data"
-            {% if action == 'add' %}
-                action="{% url "book_add" %}"
-            {% else %}
-                action="{% url "book_edit" book.pk %}"
-            {% endif %}
-            method="POST">
-        {% csrf_token %}
-        {{ form.media }}
+<form enctype="multipart/form-data" action="{% url "book_edit" book.pk %}" method="POST" class="form-horizontal">
+    {% csrf_token %}
+    <div class="row">
+        <fieldset>
+            <legend>Edit Book</legend>
+            
+            {% if form.cover_img %}
+            <div class="col-md-2">
+                <div class="col-md-12">
+                {% if form.cover_img %}
+                    {# TODO: use CSS for the img #}
+                    <img src="{% if book.cover_img %}{{ book.cover_img.url }}{% else %}{% static "images/book-icon.png" %}{% endif %}"
+                         alt="Cover" width="180px"/>
 
-        <div class="detail_sidebar">
-            {% if book.cover_img %}
-                <img src="{{ book.cover_img.url }}" alt="Cover" width=180px/>
-                {% bootstrap_field form.remove_cover_img %}
+                    {# TODO: prettify control #}
+                    {% bootstrap_field form.cover_img show_label=False %}
+                {% endif %}
+                </div>
+            </div>
+            
+            <div class="col-md-10">
             {% else %}
-                <img src="{% static "images/book-icon.png" %}" alt="Cover"
-                        width=180px/>
-                <br/><br/>
+            <div class="col-md-12">
             {% endif %}
-            {% bootstrap_field form.cover_img show_label=False %}
-            <input type="submit" class="btn btn-sm btn-primary"
-            {% if action == 'add' %}
-                value="Add">
-            {% else %}
-                value="{% trans "Edit" %}">
-            {% endif %}
-            <a href="{% url "book_detail" book.pk %}">
-                <button type="button" class="btn btn-secondary btn-sm"
-                >{% trans "Cancel" %}</button>
-            </a>
-
-        </div>
+                {% for field in form %}
+                    {% if field.name != "cover_img" %}
+                        <div class="row">
+                            {% bootstrap_field field layout="horizontal" horizontal_label_class="col-md-2" horizontal_field_class=field.name|field_width %}
+                        </div>
+                    {% endif %}
+                {% endfor %}
+            </div>
+            
 
         <fieldset>
-            <legend>
-                {% if action == 'add' %}
-                    Add Book
-                {% else %}
-                    Edit Book
-                {% endif %}
-            </legend>
+    </div>
 
-            {% if form.non_field_errors %}
-                <div class="alert alert-error">
-                    <strong>{{ form.non_field_errors }}</strong>
-                </div>
-            {% endif %}
-
-            <div class="row">
-                <div class="col-sm-3 required">{% trans "Title:" %}</div>
-                <div class="col-sm-8">
-                    {% bootstrap_field form.title show_label=False %}
-                    {{ form.title.errors }}
-                </div>
-            </div>
-
-            <div class="row">
-                <div class="col-sm-3">{% trans "Author(s):" %}</div>
-                <div class="col-sm-8">
-                    {% bootstrap_field form.authors show_label=False %}
-{#                    set_required=False#}
-                    {{ form.authors.errors }}
-                </div>
-            </div>
-
-            <div class="row">
-                <div class="col-sm-3">{% trans "Publisher(s):" %}</div>
-                <div class="col-sm-8">
-                    {% bootstrap_field form.publishers show_label=False %}
-{#                    set_required=False#}
-                </div>
-            </div>
-
-            <div class="row">
-                <div class="col-sm-3">{% trans "Language:" %}</div>
-                <div class="col-sm-5">
-                    {% bootstrap_field form.dc_language show_label=False %}
-                </div>
-            </div>
-
-            <div class="row">
-                <div class="col-sm-3">{% trans "Published:" %}</div>
-                <div class="col-sm-3">
-                    {% bootstrap_field form.dc_issued show_label=False %}
-                </div>
-            </div>
-
-            <div class="row">
-                <div class="col-sm-3 required">{% trans "Status:" %}</div>
-                <div class="col-sm-3">
-                    {% bootstrap_field form.a_status show_label=False %}
-                    {{ form.a_status.errors }}
-                </div>
-            </div>
-
-            <div class="row">
-                <div class="col-sm-3">{% trans "Tags:" %}</div>
-                <div class="col-sm-8">
-                    {% bootstrap_field form.tags show_label=False %}
-                </div>
-            </div>
-
-            {% if user.is_superuser %}
-                <div class="row">
-                    <div class="col-sm-3">{% trans "Downloads" %}:</div>
-                    <div class="col-sm-2">
-                        {% bootstrap_field form.downloads show_label=False %}
-                    </div>
-                </div>    {% endif %}
-
-            <div class="row">
-                <div class="col-sm-11">
-                    {% bootstrap_field form.summary %}
-                    </div>
-            </div>
-
-{#            <div class="col-sm-4 last">#}
-{#                <input type="submit" class="btn btn-sm btn-default"#}
-{#                        {% if action == 'add' %}#}
-{#                            value="Add">#}
-{#                        {% else %}#}
-{#                            value="{% trans "Edit" %}">#}
-{#                        {% endif %}#}
-{#            </div>#}
-        </fieldset>
-
-    </form>
-
+	<div class="row text-center">
+	    {% buttons %}
+	       {% bootstrap_button "Save" button_type="submit" %}
+	       {# TODO: link to details, not / #}
+	       {% bootstrap_button "Cancel" href="/" button_class="btn-default" %}
+	    {% endbuttons %}
+	</div>
+</form>
+</div>
 {% endblock %}
 
 {% block footer %}
-
 {% endblock %}

--- a/templates/books/book_form.html
+++ b/templates/books/book_form.html
@@ -1,68 +1,15 @@
 {% extends "base.html" %}
 {% load i18n %}
-{% load static from staticfiles %}
 {% load bootstrap3 %}
-{% load book_edit %}
 
-{% block title %}{% if action == 'add' %}
-    Add Book
-{% else %}
-    {% trans "Editing" %} - {{ book.title }}
-{% endif %}
-{% endblock %}
+{% block title %}{% trans "Editing" %} - {{ book.title }}{% endblock %}
 
 {% block extra_head %}
 {{ form.media }}
 {% endblock %}
 
-{# TODO: i8n #}
 {% block content %}
-<form enctype="multipart/form-data" action="{% url "book_edit" book.pk %}" method="POST" class="form-horizontal">
-    {% csrf_token %}
-    <div class="row">
-        <fieldset>
-            <legend>Edit Book</legend>
-            
-            {% if form.cover_img %}
-            <div class="col-md-2">
-                <div class="col-md-12">
-                {% if form.cover_img %}
-                    {# TODO: use CSS for the img #}
-                    <img src="{% if book.cover_img %}{{ book.cover_img.url }}{% else %}{% static "images/book-icon.png" %}{% endif %}"
-                         alt="Cover" width="180px"/>
-
-                    {# TODO: prettify control #}
-                    {% bootstrap_field form.cover_img show_label=False %}
-                {% endif %}
-                </div>
-            </div>
-            
-            <div class="col-md-10">
-            {% else %}
-            <div class="col-md-12">
-            {% endif %}
-                {% for field in form %}
-                    {% if field.name != "cover_img" %}
-                        <div class="row">
-                            {% bootstrap_field field layout="horizontal" horizontal_label_class="col-md-2" horizontal_field_class=field.name|field_width %}
-                        </div>
-                    {% endif %}
-                {% endfor %}
-            </div>
-            
-
-        <fieldset>
-    </div>
-
-	<div class="row text-center">
-	    {% buttons %}
-	       {% bootstrap_button "Save" button_type="submit" %}
-	       {# TODO: link to details, not / #}
-	       {% bootstrap_button "Cancel" href="/" button_class="btn-default" %}
-	    {% endbuttons %}
-	</div>
-</form>
-</div>
+{% include "books/snippets/book_edit_form.html" with form=form book=book legend="Edit Book" %}
 {% endblock %}
 
 {% block footer %}

--- a/templates/books/book_form.html
+++ b/templates/books/book_form.html
@@ -9,7 +9,9 @@
 {% endblock %}
 
 {% block content %}
-{% include "books/snippets/book_edit_form.html" with form=form book=book legend="Edit Book" %}
+<form action="" method="post" enctype="multipart/form-data" class="form-horizontal">
+    {% include "books/snippets/book_edit_form.html" with form=form book=book legend="Edit Book" buttons=True %}
+</form>
 {% endblock %}
 
 {% block footer %}

--- a/templates/books/book_form.html
+++ b/templates/books/book_form.html
@@ -10,7 +10,7 @@
 
 {% block content %}
 <form action="" method="post" enctype="multipart/form-data" class="form-horizontal">
-    {% include "books/snippets/book_edit_form.html" with form=form book=book legend="Edit Book" buttons=True %}
+    {% include "books/snippets/book_edit_form.html" with form=form book=book legend=_("Edit Book") buttons=True %}
 </form>
 {% endblock %}
 

--- a/templates/books/snippets/book_edit_form.html
+++ b/templates/books/snippets/book_edit_form.html
@@ -21,9 +21,8 @@ Snippet that renders the fields of a form used for editing a Book's metadata.
         <div class="col-md-2">
             <div class="col-md-12">
             {% if form.cover_img %}
-                {# TODO: use CSS for the img #}
                 <img src="{% if book.cover_img %}{{ book.cover_img.url }}{% else %}{% static "images/book-icon.png" %}{% endif %}"
-                     alt="Cover" width="180px"/>
+                     alt="Cover" class="cover_detail" />
 
                 {# TODO: prettify control #}
                 {% bootstrap_field form.cover_img show_label=False %}

--- a/templates/books/snippets/book_edit_form.html
+++ b/templates/books/snippets/book_edit_form.html
@@ -1,0 +1,59 @@
+{% comment %}
+Snippet that renders a form used for editing a Book.
+
+:param form: ModelForm for a Book
+:param book: Book instance (optional)
+:param legend: string with the fieldset legend
+{% endcomment %}
+
+{% load i18n %}
+{% load static from staticfiles %}
+{% load bootstrap3 %}
+{% load book_edit %}
+
+{# TODO: i8n #}
+
+<form enctype="multipart/form-data" action="" method="POST" class="form-horizontal">
+    {% csrf_token %}
+    <div class="row">
+        <fieldset>
+            <legend>{% trans legend %}</legend>
+
+            {% if form.cover_img %}
+            <div class="col-md-2">
+                <div class="col-md-12">
+                {% if form.cover_img %}
+                    {# TODO: use CSS for the img #}
+                    <img src="{% if book.cover_img %}{{ book.cover_img.url }}{% else %}{% static "images/book-icon.png" %}{% endif %}"
+                         alt="Cover" width="180px"/>
+
+                    {# TODO: prettify control #}
+                    {% bootstrap_field form.cover_img show_label=False %}
+                {% endif %}
+                </div>
+            </div>
+
+            <div class="col-md-10">
+            {% else %}
+            <div class="col-md-12">
+            {% endif %}
+                {% for field in form %}
+                    {% if field.name != "cover_img" %}
+                        <div class="row">
+                            {% bootstrap_field field layout="horizontal" horizontal_label_class="col-md-2" horizontal_field_class=field.name|field_width %}
+                        </div>
+                    {% endif %}
+                {% endfor %}
+            </div>
+
+        <fieldset>
+    </div>
+
+    <div class="row text-center">
+        {% buttons %}
+           {% bootstrap_button "Save" button_type="submit" %}
+           {# TODO: link to details, not / #}
+           {% bootstrap_button "Cancel" href="/" button_class="btn-default" %}
+        {% endbuttons %}
+    </div>
+</form>

--- a/templates/books/snippets/book_edit_form.html
+++ b/templates/books/snippets/book_edit_form.html
@@ -1,5 +1,5 @@
 {% comment %}
-Snippet that renders a form used for editing a Book.
+Snippet that renders the fields of a form used for editing a Book's metadata.
 
 :param form: ModelForm for a Book
 :param book: Book instance (optional)
@@ -12,7 +12,6 @@ Snippet that renders a form used for editing a Book.
 {% load bootstrap3 %}
 {% load book_edit %}
 
-{# TODO: i8n #}
 {% csrf_token %}
 <div class="row">
     <fieldset>
@@ -51,9 +50,8 @@ Snippet that renders a form used for editing a Book.
 {% if buttons %}
     <div class="row text-center">
         {% buttons %}
-           {# TODO: link to details, not / #}
-           {% bootstrap_button "Cancel" href="/" button_class="btn-default" %}
-           {% bootstrap_button "Save" button_type="submit" button_class="btn-success" %}
+           {% bootstrap_button _("Cancel") href=book.get_absolute_url button_class="btn-default" %}
+           {% bootstrap_button _("Save") button_type="submit" button_class="btn-success" %}
         {% endbuttons %}
     </div>
 {% endif %}

--- a/templates/books/snippets/book_edit_form.html
+++ b/templates/books/snippets/book_edit_form.html
@@ -4,6 +4,7 @@ Snippet that renders a form used for editing a Book.
 :param form: ModelForm for a Book
 :param book: Book instance (optional)
 :param legend: string with the fieldset legend
+:param buttons: boolean for showing buttons
 {% endcomment %}
 
 {% load i18n %}
@@ -12,48 +13,47 @@ Snippet that renders a form used for editing a Book.
 {% load book_edit %}
 
 {# TODO: i8n #}
+{% csrf_token %}
+<div class="row">
+    <fieldset>
+        <legend>{% trans legend %}</legend>
 
-<form enctype="multipart/form-data" action="" method="POST" class="form-horizontal">
-    {% csrf_token %}
-    <div class="row">
-        <fieldset>
-            <legend>{% trans legend %}</legend>
-
-            {% if form.cover_img %}
-            <div class="col-md-2">
-                <div class="col-md-12">
-                {% if form.cover_img %}
-                    {# TODO: use CSS for the img #}
-                    <img src="{% if book.cover_img %}{{ book.cover_img.url }}{% else %}{% static "images/book-icon.png" %}{% endif %}"
-                         alt="Cover" width="180px"/>
-
-                    {# TODO: prettify control #}
-                    {% bootstrap_field form.cover_img show_label=False %}
-                {% endif %}
-                </div>
-            </div>
-
-            <div class="col-md-10">
-            {% else %}
+        {% if form.cover_img %}
+        <div class="col-md-2">
             <div class="col-md-12">
+            {% if form.cover_img %}
+                {# TODO: use CSS for the img #}
+                <img src="{% if book.cover_img %}{{ book.cover_img.url }}{% else %}{% static "images/book-icon.png" %}{% endif %}"
+                     alt="Cover" width="180px"/>
+
+                {# TODO: prettify control #}
+                {% bootstrap_field form.cover_img show_label=False %}
             {% endif %}
-                {% for field in form %}
-                    {% if field.name != "cover_img" %}
-                        <div class="row">
-                            {% bootstrap_field field layout="horizontal" horizontal_label_class="col-md-2" horizontal_field_class=field.name|field_width %}
-                        </div>
-                    {% endif %}
-                {% endfor %}
             </div>
+        </div>
 
-        <fieldset>
-    </div>
+        <div class="col-md-10">
+        {% else %}
+        <div class="col-md-12">
+        {% endif %}
+            {% for field in form %}
+                {% if field.name != "cover_img" %}
+                    <div class="row">
+                        {% bootstrap_field field layout="horizontal" horizontal_label_class="col-md-2" horizontal_field_class=field.name|field_width %}
+                    </div>
+                {% endif %}
+            {% endfor %}
+        </div>
 
+    <fieldset>
+</div>
+
+{% if buttons %}
     <div class="row text-center">
         {% buttons %}
-           {% bootstrap_button "Save" button_type="submit" %}
            {# TODO: link to details, not / #}
            {% bootstrap_button "Cancel" href="/" button_class="btn-default" %}
+           {% bootstrap_button "Save" button_type="submit" button_class="btn-success" %}
         {% endbuttons %}
     </div>
-</form>
+{% endif %}

--- a/templates/formtools/wizard/wizard_form.html
+++ b/templates/formtools/wizard/wizard_form.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load bootstrap3 %}
 
-{% block title %}Upload Book{% endblock %}
+{% block title %}{% trans "Upload Book" %}{% endblock %}
 
 {% block extra_head %}
     {{ wizard.form.media }}
@@ -11,7 +11,7 @@
 
 {% block content %}
 <div class="row">
-<h1>Upload <small>({{ wizard.steps.step1 }}/{{ wizard.steps.count }})</small></h1>
+<h1>{% trans "Upload Book" %} <small>({{ wizard.steps.step1 }}/{{ wizard.steps.count }})</small></h1>
 <hr/>
 </div>
 
@@ -20,7 +20,7 @@
         {{ wizard.management_form }}
 
         {% if wizard.steps.step0 == 1 %}
-            {% include "books/snippets/book_edit_form.html" with form=wizard.form book=book legend="Add Book" %}
+            {% include "books/snippets/book_edit_form.html" with form=wizard.form book=book legend=_("Add Book") %}
         {% else %}
             {% bootstrap_form wizard.form %}
         {% endif %}

--- a/templates/formtools/wizard/wizard_form.html
+++ b/templates/formtools/wizard/wizard_form.html
@@ -1,5 +1,8 @@
 {% extends "base.html" %}
 {% load i18n %}
+{% load bootstrap3 %}
+
+{% block title %}Upload Book{% endblock %}
 
 {% block extra_head %}
     {{ wizard.form.media }}
@@ -7,25 +10,38 @@
 {% endblock %}
 
 {% block content %}
-    <p>Step {{ wizard.steps.step1 }} of {{ wizard.steps.count }}</p>
-    <form action="" method="post" enctype=multipart/form-data>
-        {% csrf_token %}
-        <table>
-            {{ wizard.management_form }}
+<div class="row">
+<h1>Upload <small>({{ wizard.steps.step1 }}/{{ wizard.steps.count }})</small></h1>
+<hr/>
+</div>
 
-            {% if wizard.steps.step0 == 1 %}
-                {% include "books/snippets/book_edit_form.html" with form=wizard.form book=book legend="Add Book" %}
-            {% else %}
-                {{ wizard.form }}
-            {% endif %}
-        </table>
+<form action="" method="post" enctype="multipart/form-data" class="form-horizontal">
+    {% csrf_token %}
+        {{ wizard.management_form }}
 
-        {% if wizard.steps.prev %}
-            <button name="wizard_goto_step" type="submit"
-                    value="{{ wizard.steps.first }}">{% trans "first step" %}</button>
-            <button name="wizard_goto_step" type="submit"
-                    value="{{ wizard.steps.prev }}">{% trans "prev step" %}</button>
+        {% if wizard.steps.step0 == 1 %}
+            {% include "books/snippets/book_edit_form.html" with form=wizard.form book=book legend="Add Book" %}
+        {% else %}
+            {% bootstrap_form wizard.form %}
         {% endif %}
-        <input type="submit" value="{% trans "submit" %}"/>
-    </form>
+
+    <div class="row text-center">
+    {% buttons %}
+        {% if wizard.steps.prev %}
+           {# This piece assumes there are only 2 steps. #}
+           {# Refer to formtools docs if this changes in the future. #}
+           {% bootstrap_button _("First step") name="wizard_goto_step" value="0" button_type="submit" button_class="btn-default" %}
+        {% endif %}
+
+        {% if wizard.steps.current == wizard.steps.last %}
+           {% bootstrap_button _("Add Book") button_type="submit" value=_("Add Book") button_class="btn-success" %}
+        {% else %}
+           {% bootstrap_button _("Next step") button_type="submit" value=_("Next step") %}
+        {% endif %}
+    {% endbuttons %}
+    </div>
+</form>
+{% endblock %}
+
+{% block footer %}
 {% endblock %}

--- a/templates/formtools/wizard/wizard_form.html
+++ b/templates/formtools/wizard/wizard_form.html
@@ -1,8 +1,9 @@
 {% extends "base.html" %}
 {% load i18n %}
 
-{% block head %}
+{% block extra_head %}
     {{ wizard.form.media }}
+    {{ form.media }}
 {% endblock %}
 
 {% block content %}
@@ -11,15 +12,14 @@
         {% csrf_token %}
         <table>
             {{ wizard.management_form }}
-            {% if wizard.form.forms %}
-                {{ wizard.form.management_form }}
-                {% for form in wizard.form.forms %}
-                    {{ form }}
-                {% endfor %}
+
+            {% if wizard.steps.step0 == 1 %}
+                {% include "books/snippets/book_edit_form.html" with form=wizard.form book=book legend="Add Book" %}
             {% else %}
                 {{ wizard.form }}
             {% endif %}
         </table>
+
         {% if wizard.steps.prev %}
             <button name="wizard_goto_step" type="submit"
                     value="{{ wizard.steps.first }}">{% trans "first step" %}</button>


### PR DESCRIPTION
Make `BookEditView` and `AddBookWizard` share the template and the forms (by making `BookMetadataForm` a subclass of `BookEditForm`), plus cleanup the templates, forms, and related stuff in the process. This should make the code more maintainable and allow for further changes in the edit/import functionality easier to keep in sync, as discussed at #39.

The changes on `books/epub.py` (and in turn `commands/addepub.py`) revert some previous changes that were not handled properly: when modifying models or `epub.py`, it's important to make sure it does not break things elsewhere - as we do not have proper tests for the UI yet, please do be careful and check manually when introducing such changes!

Things that would need work in further iterations:
- tags are currently not imported when uploading a book. This is mainly related to the `books/epub.py` comment - we _probably_ want to move the "cleaning up" of the authors/publishers/tags/etc (strip, check for empty, cleanup) there, in order to avoid having to clean them up both on addepub and on the wizard.
- prettifying the templates.
- run `makemessages` and adjust where necessary (and double check for untranslated strings)
